### PR TITLE
Optional XML API response output support

### DIFF
--- a/api.php
+++ b/api.php
@@ -16,7 +16,8 @@ class ComponentAPI extends MashapeRestAPI
 	}
 
 	// TODO: Declare your API functions below
-	public function sayHello($name) {
+	public function sayHello($name, $output = false) {
+	  if($output) parent::setOutputToXml("timezone");
 		return "Hello " . $name . "!";
 	}
 

--- a/mashape/mashape.php
+++ b/mashape/mashape.php
@@ -30,6 +30,7 @@ require_once (dirname(__FILE__) . "/methods/handler.php");
 
 abstract class MashapeRestAPI {
 	private static $errors;
+	private static $xmlRoot;
 	public $dirPath;
 
 	protected function __construct($dirPath) {
@@ -51,6 +52,18 @@ abstract class MashapeRestAPI {
 		if (!empty($statusCode)) {
 			header("HTTP/1.0 " . $statusCode);
 		}
+	}
+
+  public static function clearOutputToXml() {
+    unset(self::$xmlRoot);
+  }
+
+  public static function getOutputToXml() {
+	  return self::$xmlRoot;
+	}
+	
+	public static function setOutputToXml($root = 'result') {
+    self::$xmlRoot = $root;
 	}
 
 	public static function parseBoolean($value) {

--- a/mashape/methods/handler.php
+++ b/mashape/methods/handler.php
@@ -29,6 +29,7 @@ require_once(dirname(__FILE__) . "/../json/jsonUtils.php");
 require_once(dirname(__FILE__) . "/../net/httpUtils.php");
 require_once(dirname(__FILE__) . "/discover/discover.php");
 require_once(dirname(__FILE__) . "/call/call.php");
+require_once(dirname(__FILE__) . "/../xml/xmlGenerator.php");
 
 define("OPERATION", "_op");
 define("CALLBACK", "callback");
@@ -97,17 +98,25 @@ class MashapeHandler {
 						throw new MashapeException(EXCEPTION_NOTSUPPORTED_OPERATION, EXCEPTION_NOTSUPPORTED_OPERATION_CODE);
 				}
 
-				$jsonpCallback = (isset($params[CALLBACK])) ? $params[CALLBACK] : null;
-				if (empty($jsonpCallback)) {
-					// Print the output
-					echo $result;
-				} else {
-					if (self::validateCallback($jsonpCallback)) {
-						echo $jsonpCallback . '(' . $result . ')';
-					} else {
-						throw new MashapeException(EXCEPTION_INVALID_CALLBACK, EXCEPTION_SYSTEM_ERROR_CODE);
-					}
-				}
+        $toXMLOutput = $instance::getOutputToXml();
+        if(isset($toXMLOutput) && $operation === "call") {
+          $JSONd = json_decode($result);
+          header("Content-type: application/xml");
+          $xmlResult = new XMLGenerator($JSONd, $toXMLOutput);
+          echo $xmlResult->toXML();
+        } else {
+  				$jsonpCallback = (isset($params[CALLBACK])) ? $params[CALLBACK] : null;
+  				if (empty($jsonpCallback)) {
+  					// Print the output
+  					echo $result;
+  				} else {
+  					if (self::validateCallback($jsonpCallback)) {
+  						echo $jsonpCallback . '(' . $result . ')';
+  					} else {
+  						throw new MashapeException(EXCEPTION_INVALID_CALLBACK, EXCEPTION_SYSTEM_ERROR_CODE);
+  					}
+  				}
+			  }
 
 			} else {
 				// Operation not supported
@@ -115,6 +124,7 @@ class MashapeHandler {
 			}
 
 		} catch (Exception $e) {
+		  $toXMLOutput = $instance::getOutputToXml();
 			//If it's an ApizatorException then print the specific code
 			if ($e instanceof MashapeException) {
 				header("Content-type: application/json");
@@ -157,11 +167,32 @@ class MashapeHandler {
 						header("HTTP/1.0 500 Internal Server Error");
 						break;
 				}
-				echo JsonUtils::serializeError($e->getMessage(), $code);
+				if(isset($toXMLOutput) && $operation === "call") {
+          header("Content-type: application/xml");
+          $errorArr = array(
+            'message' => $e->getMessage(),
+            'code' =>  $code
+          );
+          $xmlResult = new XMLGenerator($errorArr, 'error');
+          echo $xmlResult->toXML();
+        } else {
+				  echo JsonUtils::serializeError($e->getMessage(), $code);
+			  }
 			} else {
 				//Otherwise print a "generic exception" code
 				header("HTTP/1.0 500 Internal Server Error");
-				echo JsonUtils::serializeError($e->getMessage(), EXCEPTION_GENERIC_LIBRARY_ERROR_CODE);
+				
+				if(isset($toXMLOutput) && $operation === "call") {
+          header("Content-type: application/xml");
+          $errorArr = array(
+            'message' => $e->getMessage(),
+            'code' =>  EXCEPTION_GENERIC_LIBRARY_ERROR_CODE
+          );
+          $xmlResult = new XMLGenerator($errorArr, 'error');
+          echo $xmlResult->toXML();
+        } else {
+				  echo JsonUtils::serializeError($e->getMessage(), EXCEPTION_GENERIC_LIBRARY_ERROR_CODE);
+			  }
 			}
 		}
 	}

--- a/mashape/xml/xmlGenerator.php
+++ b/mashape/xml/xmlGenerator.php
@@ -1,0 +1,70 @@
+<?php
+ /**
+ * Mashape JSON to XML Generator
+ *
+ * Copyright Richard Tibbett, 2011
+ */
+class XMLGenerator {
+  
+  var $json;
+  
+  var $rootName;
+  
+  function XMLGenerator($json, $rootName = 'result') {
+    $this->json = $json;
+    $this->rootName = $rootName;
+    
+    $this->dom = new DOMDocument('1.0', 'utf-8');
+  }
+  
+  public function toXML() {
+    $body = $this->Parse($this->json);
+    return $body;
+  }
+  
+  private function Parse($json, $node = false) {
+    $root = false;
+    if (empty($node)) {
+     $node = $this->dom->createElement($this->rootName);
+     $root = true;
+    }
+
+    foreach ($json as $key => $val) {   
+       if (is_array($val) || is_object($val)) { // handle arrays/objects
+
+        foreach ($val as $skey => $sval) {
+          if($currentKey !== $key) $nNode = $this->dom->createElement($key);
+          $node->appendChild($this->Parse(array($skey => $sval), $nNode));
+          $currentKey = $key;
+        }
+
+       } else {
+        // fix boolean output
+        if($val === true) {
+          $val = "true";
+        } elseif($val === false) {
+          $val = "false";
+        }
+        $node->appendChild($this->dom->createElement($key, $val));
+       }
+    }
+
+    if ($root == true) {
+     $this->dom->appendChild($node);
+     return $this->dom->saveXML(); 
+    } else {
+     return $node;
+    }
+  }
+  
+}
+
+/*
+// TEST
+
+$jsonStr = '{"version":"1.2","url":"http:\/\/worldtimeengine.com\/current\/10_10","location":{"region":"Nigeria","latitude":10,"longitude":10},"summary":{"utc":"2011-11-25 09:52:10","local":"2011-11-25 10:52:10","hasDst":true},"current":{"abbreviation":"WAT","description":"West Africa Time","utcOffset":"+1:00"}}';
+$json = json_decode($jsonStr);
+
+$xmlgen = new XMLGenerator($json, 'timezone');
+echo $xmlgen->toXML();
+*/


### PR DESCRIPTION
This patch adds support for XML output to be returned at the discretion of the ComponentAPI.

To set the response type to XML you can simply add the following to any method in a class implementing the MashapeRestAPI (e.g. /api.php):

parent::setOutputToXml();

If you want to change the name of the root XML node (from the default <result>) then simply pass in the new name for the root node as the only parameter to the function:

parent::setOutputToXml("timezone");

That's it!

---

XML support may also need to be patched to the client libraries.
