### PR TITLE
Optional XML API response output support (refactored)

### DIFF
--- a/api.php
+++ b/api.php
@@ -16,8 +16,7 @@ class ComponentAPI extends MashapeRestAPI
 	}
 
 	// TODO: Declare your API functions below
-	public function sayHello($name, $output = false) {
-	  if($output) parent::setOutputToXml("timezone");
+	public function sayHello($name) {
 		return "Hello " . $name . "!";
 	}
 

--- a/api.php
+++ b/api.php
@@ -16,7 +16,8 @@ class ComponentAPI extends MashapeRestAPI
 	}
 
 	// TODO: Declare your API functions below
-	public function sayHello($name) {
+	public function sayHello($name, $output = false) {
+	  if($output) parent::setOutputToXml("timezone");
 		return "Hello " . $name . "!";
 	}
 

--- a/mashape/mashape.php
+++ b/mashape/mashape.php
@@ -30,6 +30,7 @@ require_once (dirname(__FILE__) . "/methods/handler.php");
 
 abstract class MashapeRestAPI {
 	private static $errors;
+	private static $xmlRoot;
 	public $dirPath;
 
 	protected function __construct($dirPath) {
@@ -51,6 +52,18 @@ abstract class MashapeRestAPI {
 		if (!empty($statusCode)) {
 			header("HTTP/1.0 " . $statusCode);
 		}
+	}
+
+  public static function clearOutputToXml() {
+    unset(self::$xmlRoot);
+  }
+
+  public static function getOutputToXml() {
+	  return self::$xmlRoot;
+	}
+	
+	public static function setOutputToXml($root = 'result') {
+    self::$xmlRoot = $root;
 	}
 
 	public static function parseBoolean($value) {

--- a/mashape/mashape.php
+++ b/mashape/mashape.php
@@ -30,7 +30,6 @@ require_once (dirname(__FILE__) . "/methods/handler.php");
 
 abstract class MashapeRestAPI {
 	private static $errors;
-	private static $xmlRoot;
 	public $dirPath;
 
 	protected function __construct($dirPath) {
@@ -54,23 +53,30 @@ abstract class MashapeRestAPI {
 		}
 	}
 
-  public static function clearOutputToXml() {
-    unset(self::$xmlRoot);
-  }
-
-  public static function getOutputToXml() {
-	  return self::$xmlRoot;
-	}
-	
-	public static function setOutputToXml($root = 'result') {
-    self::$xmlRoot = $root;
-	}
-
 	public static function parseBoolean($value) {
 		if ($value == "1" || strtolower($value) === "true") {
 			return true;
 		}
 		return false;
+	}
+
+	public static function clearErrors() {
+		self::$errors = array();
+	}
+
+	public static function hasErrors() {
+		if (empty(self::$errors)) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	public static function getErrors() {
+		return self::$errors;
+	}
+}
+ false;
 	}
 
 	public static function clearErrors() {

--- a/mashape/mashape.php
+++ b/mashape/mashape.php
@@ -30,6 +30,10 @@ require_once (dirname(__FILE__) . "/methods/handler.php");
 
 abstract class MashapeRestAPI {
 	private static $errors;
+	
+	public static $toXml = false;
+	public static $xmlRoot = 'result';
+	
 	public $dirPath;
 
 	protected function __construct($dirPath) {
@@ -52,31 +56,16 @@ abstract class MashapeRestAPI {
 			header("HTTP/1.0 " . $statusCode);
 		}
 	}
+	
+	public static function setRoot($name = 'result') {
+	  self::$xmlRoot = $name;
+	}
 
 	public static function parseBoolean($value) {
 		if ($value == "1" || strtolower($value) === "true") {
 			return true;
 		}
 		return false;
-	}
-
-	public static function clearErrors() {
-		self::$errors = array();
-	}
-
-	public static function hasErrors() {
-		if (empty(self::$errors)) {
-			return false;
-		} else {
-			return true;
-		}
-	}
-
-	public static function getErrors() {
-		return self::$errors;
-	}
-}
- false;
 	}
 
 	public static function clearErrors() {

--- a/mashape/methods/call/call.php
+++ b/mashape/methods/call/call.php
@@ -45,6 +45,8 @@ class Call implements IMethodHandler {
 		
 		$this->findMethod($parameters, $methodName, $method, $serverKey, $httpRequestMethod);
 		
+		$instance::$xmlRoot = $methodName;
+		
 		if (strtolower($method->getHttp()) != strtolower($httpRequestMethod)) {
 			throw new MashapeException(EXCEPTION_INVALID_HTTPMETHOD, EXCEPTION_INVALID_HTTPMETHOD_CODE);
 		}

--- a/mashape/methods/handler.php
+++ b/mashape/methods/handler.php
@@ -32,7 +32,6 @@ require_once(dirname(__FILE__) . "/call/call.php");
 require_once(dirname(__FILE__) . "/../xml/xmlGenerator.php");
 
 define("OPERATION", "_op");
-define("OUTPUT", "output");
 define("CALLBACK", "callback");
 
 class MashapeHandler {
@@ -79,7 +78,8 @@ class MashapeHandler {
 				throw new MashapeException(EXCEPTION_NOTSUPPORTED_HTTPMETHOD, EXCEPTION_NOTSUPPORTED_HTTPMETHOD_CODE);
 			}
 			
-			if(isset($params[OUTPUT]) && $params[OUTPUT] === 'xml') {
+			var $outputFormat = HttpUtils::getHeader("X-Output-Format");
+			if(!empty($outputFormat) && $outputFormat == 'xml') {
 			  $instance::$toXml = true;
 			}
 

--- a/mashape/methods/handler.php
+++ b/mashape/methods/handler.php
@@ -29,7 +29,6 @@ require_once(dirname(__FILE__) . "/../json/jsonUtils.php");
 require_once(dirname(__FILE__) . "/../net/httpUtils.php");
 require_once(dirname(__FILE__) . "/discover/discover.php");
 require_once(dirname(__FILE__) . "/call/call.php");
-require_once(dirname(__FILE__) . "/../xml/xmlGenerator.php");
 
 define("OPERATION", "_op");
 define("CALLBACK", "callback");
@@ -98,25 +97,17 @@ class MashapeHandler {
 						throw new MashapeException(EXCEPTION_NOTSUPPORTED_OPERATION, EXCEPTION_NOTSUPPORTED_OPERATION_CODE);
 				}
 
-        $toXMLOutput = $instance::getOutputToXml();
-        if(isset($toXMLOutput) && $operation === "call") {
-          $JSONd = json_decode($result);
-          header("Content-type: application/xml");
-          $xmlResult = new XMLGenerator($JSONd, $toXMLOutput);
-          echo $xmlResult->toXML();
-        } else {
-  				$jsonpCallback = (isset($params[CALLBACK])) ? $params[CALLBACK] : null;
-  				if (empty($jsonpCallback)) {
-  					// Print the output
-  					echo $result;
-  				} else {
-  					if (self::validateCallback($jsonpCallback)) {
-  						echo $jsonpCallback . '(' . $result . ')';
-  					} else {
-  						throw new MashapeException(EXCEPTION_INVALID_CALLBACK, EXCEPTION_SYSTEM_ERROR_CODE);
-  					}
-  				}
-			  }
+				$jsonpCallback = (isset($params[CALLBACK])) ? $params[CALLBACK] : null;
+				if (empty($jsonpCallback)) {
+					// Print the output
+					echo $result;
+				} else {
+					if (self::validateCallback($jsonpCallback)) {
+						echo $jsonpCallback . '(' . $result . ')';
+					} else {
+						throw new MashapeException(EXCEPTION_INVALID_CALLBACK, EXCEPTION_SYSTEM_ERROR_CODE);
+					}
+				}
 
 			} else {
 				// Operation not supported
@@ -124,7 +115,6 @@ class MashapeHandler {
 			}
 
 		} catch (Exception $e) {
-		  $toXMLOutput = $instance::getOutputToXml();
 			//If it's an ApizatorException then print the specific code
 			if ($e instanceof MashapeException) {
 				header("Content-type: application/json");
@@ -167,32 +157,11 @@ class MashapeHandler {
 						header("HTTP/1.0 500 Internal Server Error");
 						break;
 				}
-				if(isset($toXMLOutput) && $operation === "call") {
-          header("Content-type: application/xml");
-          $errorArr = array(
-            'message' => $e->getMessage(),
-            'code' =>  $code
-          );
-          $xmlResult = new XMLGenerator($errorArr, 'error');
-          echo $xmlResult->toXML();
-        } else {
-				  echo JsonUtils::serializeError($e->getMessage(), $code);
-			  }
+				echo JsonUtils::serializeError($e->getMessage(), $code);
 			} else {
 				//Otherwise print a "generic exception" code
 				header("HTTP/1.0 500 Internal Server Error");
-				
-				if(isset($toXMLOutput) && $operation === "call") {
-          header("Content-type: application/xml");
-          $errorArr = array(
-            'message' => $e->getMessage(),
-            'code' =>  EXCEPTION_GENERIC_LIBRARY_ERROR_CODE
-          );
-          $xmlResult = new XMLGenerator($errorArr, 'error');
-          echo $xmlResult->toXML();
-        } else {
-				  echo JsonUtils::serializeError($e->getMessage(), EXCEPTION_GENERIC_LIBRARY_ERROR_CODE);
-			  }
+				echo JsonUtils::serializeError($e->getMessage(), EXCEPTION_GENERIC_LIBRARY_ERROR_CODE);
 			}
 		}
 	}

--- a/mashape/methods/handler.php
+++ b/mashape/methods/handler.php
@@ -29,6 +29,7 @@ require_once(dirname(__FILE__) . "/../json/jsonUtils.php");
 require_once(dirname(__FILE__) . "/../net/httpUtils.php");
 require_once(dirname(__FILE__) . "/discover/discover.php");
 require_once(dirname(__FILE__) . "/call/call.php");
+require_once(dirname(__FILE__) . "/../xml/xmlGenerator.php");
 
 define("OPERATION", "_op");
 define("CALLBACK", "callback");
@@ -97,17 +98,25 @@ class MashapeHandler {
 						throw new MashapeException(EXCEPTION_NOTSUPPORTED_OPERATION, EXCEPTION_NOTSUPPORTED_OPERATION_CODE);
 				}
 
-				$jsonpCallback = (isset($params[CALLBACK])) ? $params[CALLBACK] : null;
-				if (empty($jsonpCallback)) {
-					// Print the output
-					echo $result;
-				} else {
-					if (self::validateCallback($jsonpCallback)) {
-						echo $jsonpCallback . '(' . $result . ')';
-					} else {
-						throw new MashapeException(EXCEPTION_INVALID_CALLBACK, EXCEPTION_SYSTEM_ERROR_CODE);
-					}
-				}
+        $toXMLOutput = $instance::getOutputToXml();
+        if(isset($toXMLOutput) && $operation === "call") {
+          $JSONd = json_decode($result);
+          header("Content-type: application/xml");
+          $xmlResult = new XMLGenerator($JSONd, $toXMLOutput);
+          echo $xmlResult->toXML();
+        } else {
+  				$jsonpCallback = (isset($params[CALLBACK])) ? $params[CALLBACK] : null;
+  				if (empty($jsonpCallback)) {
+  					// Print the output
+  					echo $result;
+  				} else {
+  					if (self::validateCallback($jsonpCallback)) {
+  						echo $jsonpCallback . '(' . $result . ')';
+  					} else {
+  						throw new MashapeException(EXCEPTION_INVALID_CALLBACK, EXCEPTION_SYSTEM_ERROR_CODE);
+  					}
+  				}
+			  }
 
 			} else {
 				// Operation not supported
@@ -115,6 +124,7 @@ class MashapeHandler {
 			}
 
 		} catch (Exception $e) {
+		  $toXMLOutput = $instance::getOutputToXml();
 			//If it's an ApizatorException then print the specific code
 			if ($e instanceof MashapeException) {
 				header("Content-type: application/json");
@@ -157,11 +167,32 @@ class MashapeHandler {
 						header("HTTP/1.0 500 Internal Server Error");
 						break;
 				}
-				echo JsonUtils::serializeError($e->getMessage(), $code);
+				if(isset($toXMLOutput) && $operation === "call") {
+          header("Content-type: application/xml");
+          $errorArr = array(
+            'message' => $e->getMessage(),
+            'code' =>  $code
+          );
+          $xmlResult = new XMLGenerator($errorArr, 'error');
+          echo $xmlResult->toXML();
+        } else {
+				  echo JsonUtils::serializeError($e->getMessage(), $code);
+			  }
 			} else {
 				//Otherwise print a "generic exception" code
 				header("HTTP/1.0 500 Internal Server Error");
-				echo JsonUtils::serializeError($e->getMessage(), EXCEPTION_GENERIC_LIBRARY_ERROR_CODE);
+				
+				if(isset($toXMLOutput) && $operation === "call") {
+          header("Content-type: application/xml");
+          $errorArr = array(
+            'message' => $e->getMessage(),
+            'code' =>  EXCEPTION_GENERIC_LIBRARY_ERROR_CODE
+          );
+          $xmlResult = new XMLGenerator($errorArr, 'error');
+          echo $xmlResult->toXML();
+        } else {
+				  echo JsonUtils::serializeError($e->getMessage(), EXCEPTION_GENERIC_LIBRARY_ERROR_CODE);
+			  }
 			}
 		}
 	}

--- a/mashape/methods/handler.php
+++ b/mashape/methods/handler.php
@@ -29,8 +29,10 @@ require_once(dirname(__FILE__) . "/../json/jsonUtils.php");
 require_once(dirname(__FILE__) . "/../net/httpUtils.php");
 require_once(dirname(__FILE__) . "/discover/discover.php");
 require_once(dirname(__FILE__) . "/call/call.php");
+require_once(dirname(__FILE__) . "/../xml/xmlGenerator.php");
 
 define("OPERATION", "_op");
+define("OUTPUT", "output");
 define("CALLBACK", "callback");
 
 class MashapeHandler {
@@ -59,10 +61,12 @@ class MashapeHandler {
 
 	public static function handleAPI($instance, $serverKey) {
 		header("Content-type: application/json");
+		$operation;
 		try {
 			if ($instance == null) {
 				throw new MashapeException(EXCEPTION_INSTANCE_NULL, EXCEPTION_SYSTEM_ERROR_CODE);
 			}
+			
 			$requestMethod = (isset($_SERVER['REQUEST_METHOD'])) ? strtolower($_SERVER['REQUEST_METHOD']) : null;
 			$params;
 			if ($requestMethod == 'post') {
@@ -73,6 +77,10 @@ class MashapeHandler {
 				$params = HttpUtils::parseQueryString(file_get_contents("php://input"));
 			} else {
 				throw new MashapeException(EXCEPTION_NOTSUPPORTED_HTTPMETHOD, EXCEPTION_NOTSUPPORTED_HTTPMETHOD_CODE);
+			}
+			
+			if(isset($params[OUTPUT]) && $params[OUTPUT] === 'xml') {
+			  $instance::$toXml = true;
 			}
 
 			$operation = (isset($params[OPERATION])) ? $params[OPERATION] : null;
@@ -97,17 +105,24 @@ class MashapeHandler {
 						throw new MashapeException(EXCEPTION_NOTSUPPORTED_OPERATION, EXCEPTION_NOTSUPPORTED_OPERATION_CODE);
 				}
 
-				$jsonpCallback = (isset($params[CALLBACK])) ? $params[CALLBACK] : null;
-				if (empty($jsonpCallback)) {
-					// Print the output
-					echo $result;
-				} else {
-					if (self::validateCallback($jsonpCallback)) {
-						echo $jsonpCallback . '(' . $result . ')';
-					} else {
-						throw new MashapeException(EXCEPTION_INVALID_CALLBACK, EXCEPTION_SYSTEM_ERROR_CODE);
-					}
-				}
+        if($instance::$toXml && $operation === "call") {
+          $JSONd = json_decode($result);
+          header("Content-type: application/xml");
+          $xmlResult = new XMLGenerator($JSONd, $instance::$xmlRoot);
+          echo $xmlResult->toXML();
+        } else {
+  				$jsonpCallback = (isset($params[CALLBACK])) ? $params[CALLBACK] : null;
+  				if (empty($jsonpCallback)) {
+  					// Print the output
+  					echo $result;
+  				} else {
+  					if (self::validateCallback($jsonpCallback)) {
+  						echo $jsonpCallback . '(' . $result . ')';
+  					} else {
+  						throw new MashapeException(EXCEPTION_INVALID_CALLBACK, EXCEPTION_SYSTEM_ERROR_CODE);
+  					}
+  				}
+			  }
 
 			} else {
 				// Operation not supported
@@ -157,11 +172,32 @@ class MashapeHandler {
 						header("HTTP/1.0 500 Internal Server Error");
 						break;
 				}
-				echo JsonUtils::serializeError($e->getMessage(), $code);
+				if($instance && $instance::$toXml) {
+          header("Content-type: application/xml");
+          $errorArr = array(
+            'message' => $e->getMessage(),
+            'code' =>  $code
+          );
+          $xmlResult = new XMLGenerator($errorArr, 'error');
+          echo $xmlResult->toXML();
+        } else {
+				  echo JsonUtils::serializeError($e->getMessage(), $code);
+			  }
 			} else {
 				//Otherwise print a "generic exception" code
 				header("HTTP/1.0 500 Internal Server Error");
-				echo JsonUtils::serializeError($e->getMessage(), EXCEPTION_GENERIC_LIBRARY_ERROR_CODE);
+				
+				if($instance && $instance::$toXml) {
+          header("Content-type: application/xml");
+          $errorArr = array(
+            'message' => $e->getMessage(),
+            'code' =>  EXCEPTION_GENERIC_LIBRARY_ERROR_CODE
+          );
+          $xmlResult = new XMLGenerator($errorArr, 'error');
+          echo $xmlResult->toXML();
+        } else {
+				  echo JsonUtils::serializeError($e->getMessage(), EXCEPTION_GENERIC_LIBRARY_ERROR_CODE);
+			  }
 			}
 		}
 	}

--- a/mashape/xml/xmlGenerator.php
+++ b/mashape/xml/xmlGenerator.php
@@ -30,7 +30,7 @@ class XMLGenerator {
     }
 
     foreach ($json as $key => $val) {   
-       if (is_array($val) || is_object($val)) { // handle arrays/objects
+       if (is_array($val)) { // handle arrays
 
         foreach ($val as $skey => $sval) {
           if($currentKey !== $key) $nNode = $this->dom->createElement($key);
@@ -39,12 +39,6 @@ class XMLGenerator {
         }
 
        } else {
-        // fix boolean output
-        if($val === true) {
-          $val = "true";
-        } elseif($val === false) {
-          $val = "false";
-        }
         $node->appendChild($this->dom->createElement($key, $val));
        }
     }
@@ -62,9 +56,20 @@ class XMLGenerator {
 /*
 // TEST
 
-$jsonStr = '{"version":"1.2","url":"http:\/\/worldtimeengine.com\/current\/10_10","location":{"region":"Nigeria","latitude":10,"longitude":10},"summary":{"utc":"2011-11-25 09:52:10","local":"2011-11-25 10:52:10","hasDst":true},"current":{"abbreviation":"WAT","description":"West Africa Time","utcOffset":"+1:00"}}';
-$json = json_decode($jsonStr);
+$wteJson = array(
+  "version" => "1.2",
+  "url" => "http:\/\/worldtimeengine.com\/current\/-0.1_51",
+  "location" => array(
+    "region" => "United Kingdom",
+    "latitude" => "51",
+    "longitude" => "-0.1"
+  ),
+  "summary" => array(
+    "utc" => "2011-11-24 22:45:53",
+    "local" => "2011-11-24 22:45:53"
+  )
+);
 
-$xmlgen = new XMLGenerator($json, 'timezone');
+$xmlgen = new XMLGenerator($wteJson, 'timezone');
 echo $xmlgen->toXML();
 */

--- a/mashape/xml/xmlGenerator.php
+++ b/mashape/xml/xmlGenerator.php
@@ -12,13 +12,15 @@ class XMLGenerator {
   function XMLGenerator($json, $rootName = 'result') {
     $this->json = $json;
     $this->rootName = $rootName;
-    $this->dom = new DOMDocument('1.0', 'utf-8');
   }
   
   public function toXML() {
     try {
+      $this->dom = new DOMDocument('1.0', 'utf-8');
       return $this->Parse($this->json);
     } catch(Exception $e) {}
+    $this->dom = new DOMDocument('1.0', 'utf-8');
+    $this->dom->appendChild( $this->dom->createElement($this->rootName) );
     return $this->dom->saveXML();
   }
   
@@ -39,7 +41,7 @@ class XMLGenerator {
         } 
        } elseif (is_object($val)) {
         foreach ($val as $skey => $sval) {
-          if(!$currentKey || $key !== $currentKey) $nNode = $this->dom->createElement($key);
+          if(!isset($currentKey) || $key !== $currentKey) $nNode = $this->dom->createElement($key);
           $node->appendChild($this->Parse(array($skey => $sval), $nNode));
           $currentKey = $key;
         }

--- a/mashape/xml/xmlGenerator.php
+++ b/mashape/xml/xmlGenerator.php
@@ -30,7 +30,7 @@ class XMLGenerator {
     }
 
     foreach ($json as $key => $val) {   
-       if (is_array($val)) { // handle arrays
+       if (is_array($val) || is_object($val)) { // handle arrays/objects
 
         foreach ($val as $skey => $sval) {
           if($currentKey !== $key) $nNode = $this->dom->createElement($key);
@@ -39,6 +39,12 @@ class XMLGenerator {
         }
 
        } else {
+        // fix boolean output
+        if($val === true) {
+          $val = "true";
+        } elseif($val === false) {
+          $val = "false";
+        }
         $node->appendChild($this->dom->createElement($key, $val));
        }
     }
@@ -56,20 +62,9 @@ class XMLGenerator {
 /*
 // TEST
 
-$wteJson = array(
-  "version" => "1.2",
-  "url" => "http:\/\/worldtimeengine.com\/current\/-0.1_51",
-  "location" => array(
-    "region" => "United Kingdom",
-    "latitude" => "51",
-    "longitude" => "-0.1"
-  ),
-  "summary" => array(
-    "utc" => "2011-11-24 22:45:53",
-    "local" => "2011-11-24 22:45:53"
-  )
-);
+$jsonStr = '{"version":"1.2","url":"http:\/\/worldtimeengine.com\/current\/10_10","location":{"region":"Nigeria","latitude":10,"longitude":10},"summary":{"utc":"2011-11-25 09:52:10","local":"2011-11-25 10:52:10","hasDst":true},"current":{"abbreviation":"WAT","description":"West Africa Time","utcOffset":"+1:00"}}';
+$json = json_decode($jsonStr);
 
-$xmlgen = new XMLGenerator($wteJson, 'timezone');
+$xmlgen = new XMLGenerator($json, 'timezone');
 echo $xmlgen->toXML();
 */

--- a/mashape/xml/xmlGenerator.php
+++ b/mashape/xml/xmlGenerator.php
@@ -1,0 +1,70 @@
+<?php
+ /**
+ * Mashape JSON to XML Generator
+ *
+ * Copyright Richard Tibbett, 2011
+ */
+class XMLGenerator {
+  
+  var $json;
+  
+  var $rootName;
+  
+  function XMLGenerator($json, $rootName = 'result') {
+    $this->json = $json;
+    $this->rootName = $rootName;
+    
+    $this->dom = new DOMDocument('1.0', 'utf-8');
+  }
+  
+  public function toXML() {
+    $body = $this->Parse($this->json);
+    return $body;
+  }
+  
+  private function Parse($json, $node = false) {
+    $root = false;
+    if (empty($node)) {
+     $node = $this->dom->createElement($this->rootName);
+     $root = true;
+    }
+
+    foreach ($json as $key => $val) {   
+       if (is_array($val) || is_object($val)) { // handle arrays/objects
+
+        foreach ($val as $skey => $sval) {
+          if($currentKey !== $key) $nNode = $this->dom->createElement($key);
+          $node->appendChild($this->Parse(array($skey => $sval), $nNode));
+          $currentKey = $key;
+        }
+
+       } else {
+        // fix boolean output
+        if($val === true) {
+          $val = "true";
+        } elseif($val === false) {
+          $val = "false";
+        }
+        $node->appendChild($this->dom->createElement($key, $val));
+       }
+    }
+
+    if ($root == true) {
+     $this->dom->appendChild($node);
+     return $this->dom->saveXML(); 
+    } else {
+     return $node;
+    }
+  }
+  
+}
+
+/*
+// TEST
+
+$jsonStr = '{"version":"1.2","url":"http:\/\/worldtimeengine.com\/current\/10_10","location":{"region":"Nigeria","latitude":10,"longitude":10},"summary":{"utc":"2011-11-25 09:52:10","local":"2011-11-25 10:52:10","hasDst":true},"current":{"abbreviation":"WAT","description":"West Africa Time","utcOffset":"+1:00"}}';
+$json = json_decode($jsonStr);
+
+$xmlgen = new XMLGenerator($json, 'timezone');
+echo $xmlgen->toXML();
+*/


### PR DESCRIPTION
This patch adds support for XML output to be returned if an 'X-Output-Format: xml' HTTP header has been sent from the API client.

---

Server-side API compliment to pull request #2 for mashape-api-proxy:

https://github.com/Mashape/Mashape-API-Proxy/pull/2
